### PR TITLE
fix: add subscriptionLimits to Call response object

### DIFF
--- a/src/Vapi.Net.Test/Core/Json/CallSubscriptionLimitsTests.cs
+++ b/src/Vapi.Net.Test/Core/Json/CallSubscriptionLimitsTests.cs
@@ -1,0 +1,129 @@
+using NUnit.Framework;
+using Vapi.Net.Core;
+
+namespace Vapi.Net.Test.Core.Json;
+
+[TestFixture]
+public class CallSubscriptionLimitsTests
+{
+    [Test]
+    public void Call_WithSubscriptionLimits_ShouldDeserializeCorrectly()
+    {
+        // Arrange - simulates the JSON returned by the CreateCall REST API
+        const string json = """
+            {
+                "id": "call-123",
+                "orgId": "org-456",
+                "createdAt": "2025-01-01T00:00:00Z",
+                "updatedAt": "2025-01-01T00:00:00Z",
+                "subscriptionLimits": {
+                    "concurrencyBlocked": false,
+                    "concurrencyLimit": 500,
+                    "remainingConcurrentCalls": 499
+                }
+            }
+            """;
+
+        // Act
+        var call = JsonUtils.Deserialize<Call>(json);
+
+        // Assert
+        Assert.That(call, Is.Not.Null);
+        Assert.That(call.SubscriptionLimits, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(call.SubscriptionLimits!.ConcurrencyBlocked, Is.False);
+            Assert.That(call.SubscriptionLimits!.ConcurrencyLimit, Is.EqualTo(500));
+            Assert.That(call.SubscriptionLimits!.RemainingConcurrentCalls, Is.EqualTo(499));
+        });
+    }
+
+    [Test]
+    public void Call_WithoutSubscriptionLimits_ShouldDeserializeWithNull()
+    {
+        // Arrange - simulates a response that doesn't include subscriptionLimits
+        const string json = """
+            {
+                "id": "call-123",
+                "orgId": "org-456",
+                "createdAt": "2025-01-01T00:00:00Z",
+                "updatedAt": "2025-01-01T00:00:00Z"
+            }
+            """;
+
+        // Act
+        var call = JsonUtils.Deserialize<Call>(json);
+
+        // Assert
+        Assert.That(call, Is.Not.Null);
+        Assert.That(call.SubscriptionLimits, Is.Null);
+    }
+
+    [Test]
+    public void Call_WithSubscriptionLimits_ShouldSerializeCorrectly()
+    {
+        // Arrange
+        var call = new Call
+        {
+            Id = "call-123",
+            OrgId = "org-456",
+            CreatedAt = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedAt = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SubscriptionLimits = new SubscriptionLimits
+            {
+                ConcurrencyBlocked = false,
+                ConcurrencyLimit = 500,
+                RemainingConcurrentCalls = 499,
+            },
+        };
+
+        // Act
+        var json = JsonUtils.Serialize(call);
+        var deserialized = JsonUtils.Deserialize<Call>(json);
+
+        // Assert
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized.SubscriptionLimits, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized.SubscriptionLimits!.ConcurrencyBlocked, Is.False);
+            Assert.That(deserialized.SubscriptionLimits!.ConcurrencyLimit, Is.EqualTo(500));
+            Assert.That(
+                deserialized.SubscriptionLimits!.RemainingConcurrentCalls,
+                Is.EqualTo(499)
+            );
+        });
+    }
+
+    [Test]
+    public void Call_WithConcurrencyBlocked_ShouldDeserializeCorrectly()
+    {
+        // Arrange - simulates a blocked call response
+        const string json = """
+            {
+                "id": "call-789",
+                "orgId": "org-456",
+                "createdAt": "2025-01-01T00:00:00Z",
+                "updatedAt": "2025-01-01T00:00:00Z",
+                "subscriptionLimits": {
+                    "concurrencyBlocked": true,
+                    "concurrencyLimit": 10,
+                    "remainingConcurrentCalls": 0
+                }
+            }
+            """;
+
+        // Act
+        var call = JsonUtils.Deserialize<Call>(json);
+
+        // Assert
+        Assert.That(call, Is.Not.Null);
+        Assert.That(call.SubscriptionLimits, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(call.SubscriptionLimits!.ConcurrencyBlocked, Is.True);
+            Assert.That(call.SubscriptionLimits!.ConcurrencyLimit, Is.EqualTo(10));
+            Assert.That(call.SubscriptionLimits!.RemainingConcurrentCalls, Is.EqualTo(0));
+        });
+    }
+}

--- a/src/Vapi.Net/Types/Call.cs
+++ b/src/Vapi.Net/Types/Call.cs
@@ -291,6 +291,12 @@ public record Call : IJsonOnDeserialized
     public SchedulePlan? SchedulePlan { get; set; }
 
     /// <summary>
+    /// These are the subscription limits for the org.
+    /// </summary>
+    [JsonPropertyName("subscriptionLimits")]
+    public SubscriptionLimits? SubscriptionLimits { get; set; }
+
+    /// <summary>
     /// This is the transport of the call.
     /// </summary>
     [JsonPropertyName("transport")]


### PR DESCRIPTION
## Summary

- Add `SubscriptionLimits` property to the `Call` record so the .NET SDK surfaces the `subscriptionLimits` block returned by the REST API on individual call responses (e.g. `POST /call`, `GET /call/{id}`)
- The `SubscriptionLimits` type already existed in the SDK (used by `CallBatchResponse`) but was missing from the `Call` model, causing customers to lose access to concurrency limit data when using the SDK
- Add 4 unit tests covering deserialization, serialization roundtrip, null handling, and edge case (blocked concurrency)

## Problem

When using the Vapi REST API directly, the CreateCall response includes:
```json
{
    "subscriptionLimits": {
        "concurrencyBlocked": false,
        "concurrencyLimit": 500,
        "remainingConcurrentCalls": 499
    }
}
```

But the .NET SDK's `Call` class did not have a `SubscriptionLimits` property, so this data was silently dropped during deserialization.

## Changes

- **`src/Vapi.Net/Types/Call.cs`** -- Added `SubscriptionLimits? SubscriptionLimits` property with `[JsonPropertyName("subscriptionLimits")]` attribute, following the exact same pattern as `CallBatchResponse.cs`
- **`src/Vapi.Net.Test/Core/Json/CallSubscriptionLimitsTests.cs`** -- 4 new tests:
  - Deserialize Call with subscriptionLimits present
  - Deserialize Call without subscriptionLimits (null, backward compat)
  - Serialize/deserialize roundtrip
  - Deserialize with concurrencyBlocked=true edge case

## Test Plan

- [x] All 168 tests pass (164 existing + 4 new), 0 failures
- [x] `dotnet build` succeeds with 0 errors across all target frameworks (net462, net8.0, net9.0, netstandard2.0)
- [x] Backward compatible -- existing responses without `subscriptionLimits` deserialize correctly (property is nullable)

## References

- Linear: PRO-1773