### PR TITLE
chore: notify Slack for SDK release PRs

### DIFF
--- a/.github/workflows/sdk-release-pr-notification.yml
+++ b/.github/workflows/sdk-release-pr-notification.yml
@@ -1,0 +1,146 @@
+name: SDK Release PR Notification
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notify Slack
+    if: >
+      (github.event.action == 'ready_for_review' || github.event.pull_request.draft == false) &&
+      (
+        github.event.pull_request.user.login == 'fern-api[bot]' ||
+        github.event.pull_request.user.login == 'fern-api' ||
+        contains(github.event.pull_request.head.ref, 'fern')
+      )
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK }}
+      RUNBOOK_URL: https://github.com/VapiAI/docs/blob/main/.github/runbooks/sdk-release-approval.md
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect package metadata
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo="${GITHUB_REPOSITORY#*/}"
+          package="unknown"
+          registry="unknown"
+
+          case "$repo" in
+            server-sdk-typescript)
+              package="@vapi-ai/server-sdk"
+              registry="npm"
+              ;;
+            server-sdk-python)
+              package="vapi_server_sdk"
+              registry="PyPI"
+              ;;
+            server-sdk-go)
+              package="github.com/VapiAI/server-sdk-go"
+              registry="Go modules"
+              ;;
+            server-sdk-ruby)
+              package="vapi_server_sdk"
+              registry="RubyGems"
+              ;;
+            server-sdk-csharp)
+              package="Vapi.Net"
+              registry="NuGet"
+              ;;
+            server-sdk-php)
+              package="vapi/vapi"
+              registry="Packagist"
+              ;;
+            server-sdk-swift)
+              package="Vapi"
+              registry="Swift Package Manager"
+              ;;
+          esac
+
+          version="$(node <<'NODE'
+          const fs = require('fs');
+
+          const readJson = (path) => {
+            try {
+              return JSON.parse(fs.readFileSync(path, 'utf8'));
+            } catch {
+              return undefined;
+            }
+          };
+
+          const firstMatch = (path, regex) => {
+            if (!fs.existsSync(path)) return undefined;
+            return fs.readFileSync(path, 'utf8').match(regex)?.[1];
+          };
+
+          const metadata = readJson('.fern/metadata.json');
+          const packageJson = readJson('package.json');
+          const composerJson = readJson('composer.json');
+
+          const version =
+            metadata?.sdkVersion ||
+            packageJson?.version ||
+            composerJson?.version ||
+            firstMatch('pyproject.toml', /^version = "([^"]+)"/m) ||
+            firstMatch('src/Vapi.Net/Vapi.Net.csproj', /<Version>([^<]+)<\/Version>/) ||
+            firstMatch('lib/vapi/version.rb', /VERSION = "([^"]+)"/) ||
+            'unknown';
+
+          process.stdout.write(version);
+          NODE
+          )"
+
+          {
+            echo "package=$package"
+            echo "registry=$registry"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PACKAGE_NAME: ${{ steps.package.outputs.package }}
+          PACKAGE_REGISTRY: ${{ steps.package.outputs.registry }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "::warning::PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK is not set; skipping Slack notification."
+            exit 0
+          fi
+
+          text="$(cat <<EOF
+          *SDK release PR ready for review*
+          *Repo:* \`${GITHUB_REPOSITORY}\`
+          *PR:* <${PR_URL}|#${PR_NUMBER} ${PR_TITLE}>
+          *Author:* \`${PR_AUTHOR}\`
+          *Package:* \`${PACKAGE_NAME}\` (${PACKAGE_REGISTRY})
+          *Version:* \`${PACKAGE_VERSION}\`
+          *Next:* Review and merge the PR, then publish the release tag from the SDK repo.
+          *Runbook:* <${RUNBOOK_URL}|SDK release approval runbook>
+          EOF
+          )"
+
+          payload="$(jq -n --arg text "$text" '{text: $text}')"
+          curl --fail --show-error --silent \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Linear ticket

https://linear.app/vapi/issue/PRISM-1030

## Value

vapi employees can now get a Slack alert when Fern opens an SDK release PR, instead of relying on someone to notice the PR manually.

This supports the new manual approval path: Fern opens a PR, Slack tells the release channel, a human reviews and merges it, then a human publishes the release tag.

## Evidence of value

- Adds a repo-local `pull_request` workflow for Fern-looking SDK release PRs.
- Sends the repo, PR, author, package, detected version, and release runbook link to `#production-release-observability`.
- Uses the existing `PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK` repository secret.

## API Changes (including webhooks + events)

- **Is this changing the public API?**

  - [ ] Yes
  - [x] No

- **If yes, is it backward-compatible?**
  - [ ] Yes
  - [ ] No

Non backward-compatible changes might break customers' agents. Please proceed with care and notify the team.

## Testing plan

- Parsed the workflow YAML locally.
- Confirmed the Slack webhook secret exists on the target SDK repo before opening the PR.
- After merge, the verification signal is a Slack message in `#production-release-observability` when Fern opens or reopens an SDK release PR.
- Regression signal: a Fern SDK release PR opens but no Slack message appears within a minute.
