### PR TITLE
fix: preserve SDK release notification workflow

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,4 +1,5 @@
 # Specify files that shouldn't be modified by Fern
+.github/workflows/sdk-release-pr-notification.yml
 .gitignore
 README.md
 changelog.md


### PR DESCRIPTION
## Linear ticket

https://linear.app/vapi/issue/PRISM-1195/sdk-releases-preserve-slack-notifications-across-fern-generation

## Value

Vapi employees will keep receiving SDK release PR review notifications after Fern regenerates this SDK. Fern now treats the hand-written Slack workflow as repository-owned instead of deleting it.

We found the workflow existed in every server SDK repository but was missing from each `.fernignore`.

## Evidence of value

- The notification workflow exists on `main`.
- `.fernignore` now contains the exact workflow path once.
- Only `.fernignore` changed and the diff passes whitespace validation.

## API Changes (including webhooks + events)

- **Is this changing the public API?**

  - [ ] Yes
  - [x] No

- **If yes, is it backward-compatible?**
  - [ ] Yes
  - [ ] No

Non backward-compatible changes might break customers' agents. Please proceed with care and notify the team.

## Testing plan

Merge this PR, then confirm the next Fern-generated SDK PR does not delete `.github/workflows/sdk-release-pr-notification.yml`. A missing workflow or missing release-review message in `#production-release-observability` indicates a regression.
